### PR TITLE
Use IE GPU rendering settings

### DIFF
--- a/CefEOBrowser/FormBrowser.cs
+++ b/CefEOBrowser/FormBrowser.cs
@@ -339,6 +339,16 @@ namespace CefEOBrowser
                 }
             }
 
+            try
+            {
+                using (var reg = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_GPU_RENDERING\"))
+                {
+                    if (!(reg?.GetValue("EOBrowser.exe") is int gpu) || gpu == 0)
+                        settings.DisableGpuAcceleration();
+                }
+            }
+            catch (Exception ex) { }
+
             Cef.Initialize(settings, performDependencyCheck: false, browserProcessHandler: null);
 
             Browser = new ChromiumWebBrowser(url) {


### PR DESCRIPTION
Referring to: https://github.com/RadarNyan/CefEOBrowser/issues/2#issuecomment-415605090
By default, EO uses IE registry settings to decide whether to use hardware acceleration.
I think it's better to also use it on CEF, since you wouldn't need to add a separate setting.